### PR TITLE
Add support for smaller screens

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -34,7 +34,6 @@ export const aboutText:JSX.Element = (
                             <li>Ask and answer any follow-up questions, if any</li>
                             <li>Repeat for the next person</li>
                         </ol>
-                        <p>open talk is best played on a desktop or laptop, and is not optimised for mobile screens.</p>
                     </Card.Body>
                 </Accordion.Collapse>
             </Card>

--- a/src/About.tsx
+++ b/src/About.tsx
@@ -1,10 +1,8 @@
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import Row from 'react-bootstrap/Row'
-import Col from 'react-bootstrap/Col'
 import Accordion from 'react-bootstrap/Accordion';
 import Card from 'react-bootstrap/Card';
-import { QuestionCard, DisplayCard, PlayingCard, AccordionCardDisplay } from './PlayingCard';
+import { QuestionCard, AccordionCardDisplay } from './PlayingCard';
 
 const openCard = new QuestionCard("", "Depth Level", "Question", "Category");
 openCard.uncover();

--- a/src/About.tsx
+++ b/src/About.tsx
@@ -4,7 +4,7 @@ import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
 import Accordion from 'react-bootstrap/Accordion';
 import Card from 'react-bootstrap/Card';
-import { QuestionCard, DisplayCard } from './PlayingCard';
+import { QuestionCard, DisplayCard, PlayingCard, AccordionCardDisplay } from './PlayingCard';
 
 const openCard = new QuestionCard("", "Depth Level", "Question", "Category");
 openCard.uncover();
@@ -49,27 +49,9 @@ export const aboutText:JSX.Element = (
                     <Card.Body>
                         <p>Cards in open talk have three components - Question, Category, and Depth Level</p>
                         <p>They are displayed on the card in the following manner:</p>
-                        <Row className="justify-content-center">
-                            <Col md="auto">
-                                {DisplayCard(openCard, () => {})}
-                                <p>Front of card</p>
-                            </Col>
-                            <Col md="auto">
-                                {DisplayCard(closedCard, () => {})}
-                                <p>Back of card</p>
-                            </Col>
-                        </Row>
+                        {AccordionCardDisplay(openCard, closedCard)}
                         <p>In the card below, "What are your pet peeves?" is the Question, "Self" is the Category and "Launch" is the Depth Level</p>
-                        <Row className="justify-content-center">
-                            <Col md="auto">
-                                {DisplayCard(openSampleCard, () => {})}
-                                <p>Front of card</p>
-                            </Col>
-                            <Col md="auto">
-                                {DisplayCard(closedSampleCard, () => {})}
-                                <p>Back of card</p>
-                            </Col>
-                        </Row>
+                        {AccordionCardDisplay(openSampleCard, closedSampleCard)}
                     </Card.Body>
                 </Accordion.Collapse>
             </Card>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,41 +178,41 @@ function App() {
 
   let header:JSX.Element = (
     <Container fluid>
-        <Row className="justify-content-md-center"><h1>open talk</h1></Row>
-        <Row className="justify-content-md-center"><h3>An online conversational tool</h3></Row>
+        <Row className="justify-content-center"><h1>open talk</h1></Row>
+        <Row className="justify-content-center"><h3>An online conversational tool</h3></Row>
     </Container>
   );
 
   function ScreenHeader(prop: {title:string}):JSX.Element {
     return (
-      <Row className="justify-content-md-center">
+      <Row className="justify-content-center">
         <h3>{prop.title}</h3>
       </Row>
     )
   }
 
   let deckHeader:JSX.Element = (
-    <Row className="justify-content-md-center">
+    <Row className="justify-content-center">
       <h4>Deck Selected: {deck.title}</h4>
     </Row>
   )
 
   let modeSelectButtons:JSX.Element = (
-    <Row className="justify-content-center">
-      <Col md="auto"><Button onClick={() => setMode(AppModes.SelectGameMode)}>Select another Game Mode</Button></Col>
-      <Col md="auto"><Button onClick={() => setMode(AppModes.MainScreen)}>Return to the Main Menu</Button></Col>
+    <Row className="justify-content-center" xs={2}>
+      <Col xs="auto"><Button onClick={() => setMode(AppModes.SelectGameMode)}>Select another Game Mode</Button></Col>
+      <Col xs="auto"><Button onClick={() => setMode(AppModes.MainScreen)}>Return to the Main Menu</Button></Col>
     </Row>
   )
 
   let mainMenuButton:JSX.Element = (
     <Row className="justify-content-center">
-      <Col md="auto"><Button onClick={() => setMode(AppModes.MainScreen)}>Return to the Main Menu</Button></Col>
+      <Col xs="auto"><Button onClick={() => setMode(AppModes.MainScreen)}>Return to the Main Menu</Button></Col>
     </Row>
   )
 
   let newGameButton:JSX.Element = (
     <Row className="justify-content-center">
-      <Col md="auto"><Button onClick={handleNewGame}>New Game</Button></Col>
+      <Col xs="auto"><Button onClick={handleNewGame}>New Game</Button></Col>
     </Row>
   )
 
@@ -222,22 +222,22 @@ function App() {
         <Container fluid>
           <ScreenHeader title = "Main Menu" />
           <br />
-          <Row className="justify-content-md-center">
-            <Col md="auto">
+          <Row className="justify-content-center">
+            <Col xs="auto">
               <MenuCard header = "Play" title = "open talk" cardText = "Questions to get to know people in varying levels of depth."
                 onClick = {() => {setDeck(openTalkDeck); setMode(AppModes.SelectGameMode)}} buttonText = "Play open talk" disableButton = {false}/>
             </Col>
             {hasImported &&
-            <Col md="auto">
+            <Col xs="auto">
               <MenuCard header = "Play" title = {importDeck.title} cardText = "The custom deck that you have imported previously"
                 onClick = {() => {setDeck(importDeck); setMode(AppModes.SelectGameMode)}} buttonText = {"Play  " + importDeck.title} disableButton = {false}/>
             </Col>
             }
-            <Col md="auto">
+            <Col xs="auto">
               <MenuCard header = "Import" title = "Import Custom Deck" cardText = "Import a custom deck with your own questions! Note that there can only be one imported deck loaded at a time." 
                 onClick = {() => {setMode(AppModes.Importing)}} buttonText = "Import Custom Deck" disableButton = {false}/>
             </Col>
-            <Col md="auto">
+            <Col xs="auto">
               <MenuCard header = "About" title = "About open talk" cardText = "Information about open talk, and instructions on how to play it"
                 onClick = {() => {setMode(AppModes.About)}} buttonText = "About open talk" disableButton = {false}/>
             </Col>
@@ -252,12 +252,12 @@ function App() {
           <ScreenHeader title = "Select Playing Mode" />
           {deckHeader}
           <br />
-          <Row className="justify-content-md-center">
-            <Col md="auto">
+          <Row className="justify-content-center">
+            <Col xs="auto">
               <MenuCard header = "Mode" title = "Categories" cardText = "Deck is split into its categories, choose a card from any of the categories"
                 onClick = {() => {setMode(AppModes.Categories)}} buttonText = "Select Categories Mode" disableButton = {false}/>
             </Col>
-            <Col md="auto">
+            <Col xs="auto">
               <MenuCard header = "Mode" title = "Grid" cardText = {"Cards are arranged into a 5 by 5 grid, only cards adjacent to previously revealed cards can be uncovered. Requires at least " + MIN_GRID_MODE_CARDS + " cards in the deck."}
                 onClick = {() => {setMode(AppModes.Grid)}} buttonText = "Select Grid Mode" disableButton = {(flatten(deck.cards).length < MIN_GRID_MODE_CARDS)}/>
             </Col>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -258,7 +258,7 @@ function App() {
                 onClick = {() => {setMode(AppModes.Categories)}} buttonText = "Select Categories Mode" disableButton = {false}/>
             </Col>
             <Col xs="auto">
-              <MenuCard header = "Mode" title = "Grid" cardText = {"Cards are arranged into a 5 by 5 grid, only cards adjacent to previously revealed cards can be uncovered. Requires at least " + MIN_GRID_MODE_CARDS + " cards in the deck."}
+              <MenuCard header = "Mode" title = "Grid" cardText = {"Cards are arranged into a 5 by 5 grid.\n\nRequires at least " + MIN_GRID_MODE_CARDS + " cards in the deck. Best played in landscape orientation."}
                 onClick = {() => {setMode(AppModes.Grid)}} buttonText = "Select Grid Mode" disableButton = {(flatten(deck.cards).length < MIN_GRID_MODE_CARDS)}/>
             </Col>
           </Row>
@@ -340,7 +340,7 @@ function App() {
             </div>}
             {!isValidImport &&
             <div>
-              <h5>{importDeck.title} not imported</h5>
+              <h5>Custom Deck not imported</h5>
               <p>None of the question cards typed in were imported successfully. Please return to the import deck screen and try again.</p>
             </div>}
           {hasImportError && 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -369,6 +369,7 @@ function App() {
           {aboutText}
           <br />
           {mainMenuButton}
+          <br />
         </Container>
       );
       break;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -351,8 +351,11 @@ function App() {
           }
           <br />
           <Row className="justify-content-center">
-            {isValidImport && <Col md="auto"><Button onClick={() => setMode(AppModes.SelectGameMode)}>Select Game Mode</Button></Col>}
-            <Col md="auto"><Button onClick={() => setMode(AppModes.Importing)}>Return to Import Deck screen</Button></Col>
+            {isValidImport && <Col xs="auto"><Button onClick={() => setMode(AppModes.SelectGameMode)}>Select Game Mode</Button></Col>}
+          </Row>
+          <br />
+          <Row className="justify-content-center">
+            <Col xs="auto"><Button onClick={() => setMode(AppModes.Importing)}>Return to Import Deck screen</Button></Col>
           </Row>
           <br />
         </Container>

--- a/src/Categories.tsx
+++ b/src/Categories.tsx
@@ -27,16 +27,19 @@ function Pile(cards:PlayingCard[], category:string): JSX.Element {
     return (
         <Container>
           <Col>
-            <Row className="justify-content-md-center"><h2>{category}</h2></Row>
-            <Row className="justify-content-md-center"><h5>Cards Remaining: {coveredPile.length - 1}</h5></Row>
+            <Row className="justify-content-center"><h3>{category}</h3></Row>
+            <Row className="justify-content-center"><h5>Cards Remaining: {coveredPile.length - 1}</h5></Row>
             <br />
-            <Row className="justify-content-md-center"><h5>Next Card:</h5></Row>
-            <Row className="justify-content-md-center">
+            <Row className="justify-content-center"><h5>Next Card:</h5></Row>
+            <Row className="justify-content-center">
               {DisplayCard(coveredPile[coveredPile.length - 1], nextCard)}
             </Row>
             <br />
-            <Row className="justify-content-md-center"><h5>Current Card:</h5></Row>
-            <Row className="justify-content-md-center">{DisplayCard(uncoveredPile[uncoveredPile.length - 1], () => {})}</Row>
+            <Row className="justify-content-center"><h5>Current Card:</h5></Row>
+            <Row className="justify-content-center">
+              {DisplayCard(uncoveredPile[uncoveredPile.length - 1], () => {})}
+            </Row>
+            <br />
           </Col>
         </Container>
     )
@@ -46,10 +49,10 @@ function Pile(cards:PlayingCard[], category:string): JSX.Element {
 export function CategoriesMode(prop:{deck: CardDeck}) {
   const shuffled:PlayingCard[][] = shuffleDeck(parseDeck(prop.deck.cards));
   let categories:string[] = prop.deck.categories;
-  let display:JSX.Element[] = categories.map(category => <Col md="auto">{Pile(shuffled[categories.indexOf(category)], category)}</Col>);
+  let display:JSX.Element[] = categories.map(category => <Col xs="auto">{Pile(shuffled[categories.indexOf(category)], category)}</Col>);
   return (
-        <Container fluid>
-          <Row className="justify-content-md-center">
+        <Container>
+          <Row className="justify-content-center">
             {display}
           </Row>
         </Container>

--- a/src/Grid.tsx
+++ b/src/Grid.tsx
@@ -39,7 +39,7 @@ export function GridMode(prop: {deck:CardDeck}): JSX.Element {
         }
         if (cardsOpened === 0) {
             disableInnerMostCards();
-            cardGrid[2][2] = new EmptyCard("Only cards adjacent to previously opened cards can be uncovered")
+            cardGrid[2][2] = new EmptyCard("Only cards next to previously opened cards can be uncovered")
         }
         if (row > 0) {
             cardGrid[row - 1][col].enableButton();

--- a/src/Grid.tsx
+++ b/src/Grid.tsx
@@ -17,51 +17,8 @@ export function GridMode(prop: {deck:CardDeck}): JSX.Element {
     const [cardsOpened, setCardsOpened] = React.useState(0);
     const [recentCard, setRecentCard] = React.useState<PlayingCard>(blankCard);
 
-    //disable uncover buttons for all cards
-    for (let card of cardsUsed) {
-        card.disableButton();
-    }
-
-    function uncoverCard(row:number, col:number):void {
-        gridArray[row][col].uncover();
-        gridArray[row][col].select();
-        if (recentCard !== blankCard) {
-            recentCard.deselect();
-        }
-        if (cardsOpened === 0) {
-            disableInnerMostCards();
-            gridArray[2][2] = new EmptyCard("Only cards adjacent to previously opened cards can be uncovered")
-        }
-        if (row > 0) {
-            gridArray[row - 1][col].enableButton();
-        }
-        if (row < 4) {
-            gridArray[row + 1][col].enableButton();
-        }
-        if (col > 0) {
-            gridArray[row][col - 1].enableButton();
-        }
-        if (col < 4) {
-            gridArray[row][col + 1].enableButton();
-        }
-        setRecentCard(gridArray[row][col]);
-        setGrid(gridArray);
-        setCardsOpened(cardsOpened + 1);
-    }
-
-    function disableInnerMostCards() {
-        gridArray[1][1].disableButton();
-        gridArray[1][2].disableButton();
-        gridArray[1][3].disableButton();
-        gridArray[2][1].disableButton();
-        gridArray[2][3].disableButton();
-        gridArray[3][1].disableButton();
-        gridArray[3][2].disableButton();
-        gridArray[3][3].disableButton();
-    }
-
     //create two dim array of playing cards for grid
-    const [gridArray, setGrid] = React.useState([
+    const [cardGrid, setGrid] = React.useState([
         [cardsUsed[0], cardsUsed[1], cardsUsed[2], cardsUsed[3], cardsUsed[4]],
         [cardsUsed[5], cardsUsed[6], cardsUsed[7], cardsUsed[8], cardsUsed[9]],
         [cardsUsed[10], cardsUsed[11], new EmptyCard("Uncover any of the surrounding 8 cards"), cardsUsed[12], cardsUsed[13]],
@@ -69,59 +26,92 @@ export function GridMode(prop: {deck:CardDeck}): JSX.Element {
         [cardsUsed[19], cardsUsed[20], cardsUsed[21], cardsUsed[22], cardsUsed[23]]
     ]);
 
+    //disable uncover buttons for all cards
+    for (let card of cardsUsed) {
+        card.disableButton();
+    }
+
+    function uncoverCard(row:number, col:number):void {
+        cardGrid[row][col].uncover();
+        cardGrid[row][col].select();
+        if (recentCard !== blankCard) {
+            recentCard.deselect();
+        }
+        if (cardsOpened === 0) {
+            disableInnerMostCards();
+            cardGrid[2][2] = new EmptyCard("Only cards adjacent to previously opened cards can be uncovered")
+        }
+        if (row > 0) {
+            cardGrid[row - 1][col].enableButton();
+        }
+        if (row < 4) {
+            cardGrid[row + 1][col].enableButton();
+        }
+        if (col > 0) {
+            cardGrid[row][col - 1].enableButton();
+        }
+        if (col < 4) {
+            cardGrid[row][col + 1].enableButton();
+        }
+        setRecentCard(cardGrid[row][col]);
+        setGrid(cardGrid);
+        setCardsOpened(cardsOpened + 1);
+    }
+
+    function disableInnerMostCards() {
+        cardGrid[1][1].disableButton();
+        cardGrid[1][2].disableButton();
+        cardGrid[1][3].disableButton();
+        cardGrid[2][1].disableButton();
+        cardGrid[2][3].disableButton();
+        cardGrid[3][1].disableButton();
+        cardGrid[3][2].disableButton();
+        cardGrid[3][3].disableButton();
+    }
+
     //enable the innermost cards
     if (cardsOpened === 0) {
-        gridArray[1][1].enableButton();
-        gridArray[1][2].enableButton();
-        gridArray[1][3].enableButton();
-        gridArray[2][1].enableButton();
-        gridArray[2][3].enableButton();
-        gridArray[3][1].enableButton();
-        gridArray[3][2].enableButton();
-        gridArray[3][3].enableButton();
+        cardGrid[1][1].enableButton();
+        cardGrid[1][2].enableButton();
+        cardGrid[1][3].enableButton();
+        cardGrid[2][1].enableButton();
+        cardGrid[2][3].enableButton();
+        cardGrid[3][1].enableButton();
+        cardGrid[3][2].enableButton();
+        cardGrid[3][3].enableButton();
+    }
+
+    function GridSquare(row:number, col:number):JSX.Element {
+        return (
+            <Col>{DisplayCard(cardGrid[row][col], ()=>{uncoverCard(row,col)})}</Col>
+        )
+    }
+
+    function GridRow(row:number, cols:number):JSX.Element {
+
+        let rowArr = [];
+        for (let i = 0; i < cols; i++) {
+            rowArr.push(GridSquare(row, i));
+        }
+
+        return (
+            <Row className="justify-content-center" sm={5} xs = {5}>
+                {rowArr}
+            </Row>
+        )
     }
 
     return (
-        <Container fluid>
-            <Row className="justify-content-center">
-                <Col md="auto">{DisplayCard(gridArray[0][0], ()=>{uncoverCard(0,0)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[0][1], ()=>{uncoverCard(0,1)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[0][2], ()=>{uncoverCard(0,2)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[0][3], ()=>{uncoverCard(0,3)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[0][4], ()=>{uncoverCard(0,4)})}</Col>
-            </Row>
+        <Container>
+            {GridRow(0, 5)}
             <br />
-            <Row className="justify-content-center">
-                <Col md="auto">{DisplayCard(gridArray[1][0], ()=>{uncoverCard(1,0)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[1][1], ()=>{uncoverCard(1,1)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[1][2], ()=>{uncoverCard(1,2)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[1][3], ()=>{uncoverCard(1,3)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[1][4], ()=>{uncoverCard(1,4)})}</Col>
-            </Row>
+            {GridRow(1, 5)}
             <br />
-            <Row className="justify-content-center">
-                <Col md="auto">{DisplayCard(gridArray[2][0], ()=>{uncoverCard(2,0)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[2][1], ()=>{uncoverCard(2,1)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[2][2], ()=>{uncoverCard(2,2)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[2][3], ()=>{uncoverCard(2,3)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[2][4], ()=>{uncoverCard(2,4)})}</Col>
-            </Row>
+            {GridRow(2, 5)}
             <br />
-            <Row className="justify-content-center">
-                <Col md="auto">{DisplayCard(gridArray[3][0], ()=>{uncoverCard(3,0)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[3][1], ()=>{uncoverCard(3,1)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[3][2], ()=>{uncoverCard(3,2)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[3][3], ()=>{uncoverCard(3,3)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[3][4], ()=>{uncoverCard(3,4)})}</Col>
-            </Row>
+            {GridRow(3, 5)}
             <br />
-            <Row className="justify-content-center">
-                <Col md="auto">{DisplayCard(gridArray[4][0], ()=>{uncoverCard(4,0)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[4][1], ()=>{uncoverCard(4,1)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[4][2], ()=>{uncoverCard(4,2)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[4][3], ()=>{uncoverCard(4,3)})}</Col>
-                <Col md="auto">{DisplayCard(gridArray[4][4], ()=>{uncoverCard(4,4)})}</Col>
-            </Row>
+            {GridRow(4, 5)}
         </Container>
     )
 }

--- a/src/MenuCard.tsx
+++ b/src/MenuCard.tsx
@@ -4,14 +4,18 @@ import Button from 'react-bootstrap/Button';
 export function MenuCard(prop:{header: string, title: string, cardText: string, buttonText: string, onClick:() => void, disableButton:boolean}): JSX.Element {
     
     const card = (
-        <Card style={{ width: '15rem', height: '20rem'}}>
-            <Card.Header>{prop.header}</Card.Header>
-            <Card.Body>
-            <Card.Title>{prop.title}</Card.Title>
-            <Card.Text>{prop.cardText}</Card.Text>
-            </Card.Body>
-            <Button variant="info" onClick={prop.onClick} disabled = {prop.disableButton}>{prop.buttonText} </Button>
-        </Card>
+        <>
+            <Card style={{ width: '15rem', height: '20rem'}}>
+                <Card.Header>{prop.header}</Card.Header>
+                <Card.Body>
+                <Card.Title>{prop.title}</Card.Title>
+                <Card.Text>{prop.cardText}</Card.Text>
+                </Card.Body>
+                <Button variant="info" onClick={prop.onClick} disabled = {prop.disableButton}>{prop.buttonText} </Button>
+            </Card>
+            <br />
+        </>
+        
     )
     return card;
 }

--- a/src/PlayingCard.tsx
+++ b/src/PlayingCard.tsx
@@ -2,6 +2,7 @@ import './index.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import Card from 'react-bootstrap/Card';
 import Button from 'react-bootstrap/Button';
+import { CSSProperties } from 'react';
 
 export type CardTuple = [string, string, string, string];
 
@@ -91,13 +92,14 @@ export function DisplayCard(card: PlayingCard, onClick:() => void): JSX.Element 
     let selected: boolean = card.selected;
     const buttonEnabled: boolean = card.buttonEnabled;
 
+    let cardStyle:CSSProperties = {width:'100%', maxWidth:'12rem', minHeight: '18rem', wordBreak:'break-word'}
     let displayed:JSX.Element;
 
     if (covered) {
       displayed = <Card 
                 bg='light'
                 text='dark' 
-                style={{ width: '12rem', height: '18rem'}}>
+                style={cardStyle}>
                 <Card.Header>{depth}</Card.Header>
                 <Card.Body>
                   <Card.Title>{category}</Card.Title>
@@ -113,7 +115,7 @@ export function DisplayCard(card: PlayingCard, onClick:() => void): JSX.Element 
       displayed = <Card 
                 bg='info'
                 text='white' 
-                style={{ width: '12rem', height: '18rem'}}>
+                style={cardStyle}>
                 <Card.Header>{depth}</Card.Header>
                 <Card.Body>
                   <Card.Title>{title}</Card.Title>
@@ -125,7 +127,7 @@ export function DisplayCard(card: PlayingCard, onClick:() => void): JSX.Element 
       displayed = <Card 
                 bg='dark'
                 text='white' 
-                style={{ width: '12rem', height: '18rem'}}>
+                style={cardStyle}>
                 <Card.Header>{depth}</Card.Header>
                 <Card.Body>
                   <Card.Title>{title}</Card.Title>

--- a/src/PlayingCard.tsx
+++ b/src/PlayingCard.tsx
@@ -1,5 +1,7 @@
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import Row from 'react-bootstrap/Row'
+import Col from 'react-bootstrap/Col'
 import Card from 'react-bootstrap/Card';
 import Button from 'react-bootstrap/Button';
 import { CSSProperties } from 'react';
@@ -137,4 +139,27 @@ export function DisplayCard(card: PlayingCard, onClick:() => void): JSX.Element 
               </Card>
     }
     return displayed;
+}
+
+export function AccordionCardDisplay(frontCard:PlayingCard, backCard:PlayingCard):JSX.Element {
+  return (
+    <>
+      <Row>
+          <Col className="d-flex justify-content-center">
+                  {DisplayCard(frontCard, () => {})}
+          </Col>
+          <Col className="d-flex justify-content-center">
+                  {DisplayCard(backCard, () => {})}
+          </Col>
+      </Row>
+      <Row>
+        <Col className="d-flex justify-content-center">
+          <p>Front of card</p>
+        </Col>
+        <Col className="d-flex justify-content-center">
+          <p>Back of card</p>
+        </Col>
+      </Row>
+    </>
+  )
 }

--- a/src/importExportFile.tsx
+++ b/src/importExportFile.tsx
@@ -1,10 +1,8 @@
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import Row from 'react-bootstrap/Row'
-import Col from 'react-bootstrap/Col'
 import Accordion from 'react-bootstrap/Accordion';
 import Card from 'react-bootstrap/Card';
-import { CardTuple, QuestionCard, DisplayCard, AccordionCardDisplay } from './PlayingCard';
+import { CardTuple, QuestionCard, AccordionCardDisplay } from './PlayingCard';
 import { CardDeck } from "./decks";
 
 export function ExportDeck(prop: {deck:CardDeck}): JSX.Element {

--- a/src/importExportFile.tsx
+++ b/src/importExportFile.tsx
@@ -4,7 +4,7 @@ import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
 import Accordion from 'react-bootstrap/Accordion';
 import Card from 'react-bootstrap/Card';
-import { CardTuple, QuestionCard, DisplayCard } from './PlayingCard';
+import { CardTuple, QuestionCard, DisplayCard, AccordionCardDisplay } from './PlayingCard';
 import { CardDeck } from "./decks";
 
 export function ExportDeck(prop: {deck:CardDeck}): JSX.Element {
@@ -44,16 +44,7 @@ export const importText:JSX.Element = (
                 </Accordion.Toggle>
                 <Accordion.Collapse eventKey="0">
                     <Card.Body>
-                        <Row className="justify-content-center">
-                            <Col md="auto">
-                                {DisplayCard(openCard, () => {})}
-                                <p>Front of card</p>
-                            </Col>
-                            <Col md="auto">
-                                {DisplayCard(closedCard, () => {})}
-                                <p>Back of card</p>
-                            </Col>
-                        </Row>
+                        {AccordionCardDisplay(openCard, closedCard)}
                     </Card.Body>
                 </Accordion.Collapse>
             </Card>
@@ -72,16 +63,7 @@ export const importText:JSX.Element = (
                 </Accordion.Toggle>
                 <Accordion.Collapse eventKey="0">
                     <Card.Body>
-                        <Row className="justify-content-center">
-                            <Col md="auto">
-                                {DisplayCard(openSampleCard, () => {})}
-                                <p>Front of card</p>
-                            </Col>
-                            <Col md="auto">
-                                {DisplayCard(closedSampleCard, () => {})}
-                                <p>Back of card</p>
-                            </Col>
-                        </Row>
+                        {AccordionCardDisplay(openSampleCard, closedSampleCard)}
                     </Card.Body>
                 </Accordion.Collapse>
             </Card>
@@ -96,16 +78,7 @@ export const importText:JSX.Element = (
                 </Accordion.Toggle>
                 <Accordion.Collapse eventKey="0">
                     <Card.Body>
-                        <Row className="justify-content-center">
-                            <Col md="auto">
-                                {DisplayCard(openMissingCard, () => {})}
-                                <p>Front of card</p>
-                            </Col>
-                            <Col md="auto">
-                                {DisplayCard(closedMissingCard, () => {})}
-                                <p>Back of card</p>
-                            </Col>
-                        </Row>
+                        {AccordionCardDisplay(openMissingCard, closedMissingCard)}
                     </Card.Body>
                 </Accordion.Collapse>
             </Card>


### PR DESCRIPTION
Previously I blindly used md="auto" for most of my Cols and Rows and that led to open talk messing up on smaller screens.

Let's
* Change the default viewport to xs to accomodate most screen sizes
* Make DisplayCards variable width and height
* Simplify the code of Grid Mode to make editing the properties of its Rows and Cols much easier
* Abstract out the display of the cards in the Accordions in the Import Deck and About screens
* Update descriptions regarding mobile support